### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix swallowed Setenv error and missing centralized error handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-03-15: [Medium - Ignored Errors] Ensure errors from OS operations like Setenv are correctly evaluated and routed to centralized error handling rather than swallowed or inverted.

--- a/error.go
+++ b/error.go
@@ -1,0 +1,11 @@
+package gocfg
+
+import (
+	"log"
+)
+
+// reportError is a centralized error reporting function.
+// All unexpected or unrecoverable errors must be funneled through this function instead of failing silently.
+func reportError(err error, context map[string]interface{}) {
+	log.Printf("ERROR: %v | Context: %v\n", err, context)
+}

--- a/gocfg.go
+++ b/gocfg.go
@@ -8,103 +8,102 @@ import (
 	"strings"
 )
 
-
 type Config map[string]SectionProvider
 
 func NewConfig() Config {
-    return Config{}
+	return Config{}
 }
 
 // RawSet sets a value on a key in a section
 func (c Config) RawSet(section string, key string, value string) bool {
-    sec, ok := c[section]
-    if !ok {
-        sec = NewMapSectionProvider()
-        c[section] = sec
-    }
-    return sec.RawSet(key, value)
+	sec, ok := c[section]
+	if !ok {
+		sec = NewMapSectionProvider()
+		c[section] = sec
+	}
+	return sec.RawSet(key, value)
 }
 
 // RawGet returns empty string if undefined
 func (c Config) RawGet(section string, key string) string {
-    sec, ok := c[section]
-    if !ok {
-        return ""
-    }
-    return sec.RawGet(key)
+	sec, ok := c[section]
+	if !ok {
+		return ""
+	}
+	return sec.RawGet(key)
 }
 
 func (c Config) RawHasSection(section string) bool {
-    _, ok := c[section]
-    return ok
+	_, ok := c[section]
+	return ok
 }
 
 func (c Config) RawHasKey(section string, key string) bool {
-    _, ok := c[section]
-    if !ok {
-        return false
-    }
-    return c[section].RawHasKey(key)
+	_, ok := c[section]
+	if !ok {
+		return false
+	}
+	return c[section].RawHasKey(key)
 }
 
 var (
-    ErrUnfinishedSection = errors.New("Unfinished section expression")
-    ErrInvalidAttributionSection = errors.New("Invalid attribution section")
+	ErrUnfinishedSection         = errors.New("Unfinished section expression")
+	ErrInvalidAttributionSection = errors.New("Invalid attribution section")
 )
 
 func (c Config) InjestReader(r io.Reader) error {
-    scanner := bufio.NewScanner(r)
-    currentSection := ""
-    lineno := 0
-    for scanner.Scan() {
-        var splitted []string
-        if scanner.Err() != nil {
-            return scanner.Err()
-        }
-        lineno++
-        line := scanner.Text()
-        i := 0
-        for ; i < len(line); i++ {
-            if line[i] == ' ' {
-                continue
-            }
-            if line[i] == ';' || line[i] == '#' {
-                goto lineend // skip line
-            }
-            if line[i] == '[' {
-                i++
-                j := i
-                stack := 0
-                for ; j < len(line); j++ {
-                    if line[j] == '[' {
-                        stack++
-                        continue
-                    }
-                    if line[j] == ']' {
-                        if stack > 0 {
-                            stack--
-                            continue
-                        }
-                        currentSection = line[i:j]
-                        goto lineend
-                    }
-                }
-                return fmt.Errorf("%w near line %d", ErrUnfinishedSection, lineno)
-            }
-            goto handle_attribution
-        }
-        goto lineend
-        handle_attribution:
-        splitted = strings.Split(line, "=")
-        if len(splitted) < 2 {
-            return fmt.Errorf("%w near line %d", ErrInvalidAttributionSection, lineno)
-        }
-        c.RawSet(
-            currentSection, 
-            strings.Trim(splitted[0], " "),
-            strings.Trim(strings.Join(splitted[1:], "="), " "),
-        )
-        lineend:
-    }
-    return nil
+	scanner := bufio.NewScanner(r)
+	currentSection := ""
+	lineno := 0
+	for scanner.Scan() {
+		var splitted []string
+		if scanner.Err() != nil {
+			return scanner.Err()
+		}
+		lineno++
+		line := scanner.Text()
+		i := 0
+		for ; i < len(line); i++ {
+			if line[i] == ' ' {
+				continue
+			}
+			if line[i] == ';' || line[i] == '#' {
+				goto lineend // skip line
+			}
+			if line[i] == '[' {
+				i++
+				j := i
+				stack := 0
+				for ; j < len(line); j++ {
+					if line[j] == '[' {
+						stack++
+						continue
+					}
+					if line[j] == ']' {
+						if stack > 0 {
+							stack--
+							continue
+						}
+						currentSection = line[i:j]
+						goto lineend
+					}
+				}
+				return fmt.Errorf("%w near line %d", ErrUnfinishedSection, lineno)
+			}
+			goto handle_attribution
+		}
+		goto lineend
+	handle_attribution:
+		splitted = strings.Split(line, "=")
+		if len(splitted) < 2 {
+			return fmt.Errorf("%w near line %d", ErrInvalidAttributionSection, lineno)
+		}
+		c.RawSet(
+			currentSection,
+			strings.Trim(splitted[0], " "),
+			strings.Trim(strings.Join(splitted[1:], "="), " "),
+		)
+	lineend:
+	}
+	return nil
 }

--- a/gocfg_test.go
+++ b/gocfg_test.go
@@ -29,11 +29,11 @@ isthisright = true
 `
 
 func TestParseLine(t *testing.T) {
-    c := NewConfig()
-    r := bytes.NewBufferString(demoCFG)
-    err := c.InjestReader(r)
-    if err != nil {
-        t.Error(err)
-    }
-    json.NewEncoder(os.Stdout).Encode(c)
+	c := NewConfig()
+	r := bytes.NewBufferString(demoCFG)
+	err := c.InjestReader(r)
+	if err != nil {
+		t.Error(err)
+	}
+	json.NewEncoder(os.Stdout).Encode(c)
 }

--- a/gocfg_test.go
+++ b/gocfg_test.go
@@ -35,5 +35,7 @@ func TestParseLine(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	json.NewEncoder(os.Stdout).Encode(c)
+	if err := json.NewEncoder(os.Stdout).Encode(c); err != nil {
+		t.Error(err)
+	}
 }

--- a/sectionprovider.go
+++ b/sectionprovider.go
@@ -44,7 +44,15 @@ func (envSectionProvider) RawGet(key string) string {
 }
 
 func (envSectionProvider) RawSet(key string, value string) bool {
-    return os.Setenv(key, value) != nil
+    err := os.Setenv(key, value)
+    if err != nil {
+        reportError(err, map[string]interface{}{
+            "action": "Setenv",
+            "key":    key,
+        })
+        return false
+    }
+    return true
 }
 
 func (envSectionProvider) RawHasKey(key string) bool {

--- a/sectionprovider.go
+++ b/sectionprovider.go
@@ -3,36 +3,36 @@ package gocfg
 import "os"
 
 type SectionProvider interface {
-    // RawGet gets a string value from the section provider, "" if not defined
-    RawGet(key string) (value string)
-    // RawSet sets a string value on a section provider, false if not writeable
-    RawSet(key string, value string) (success bool)
-    // RawHasKey checks if the key exists in the section
-    RawHasKey(key string) (hasKey bool)
+	// RawGet gets a string value from the section provider, "" if not defined
+	RawGet(key string) (value string)
+	// RawSet sets a string value on a section provider, false if not writeable
+	RawSet(key string, value string) (success bool)
+	// RawHasKey checks if the key exists in the section
+	RawHasKey(key string) (hasKey bool)
 }
 
 type MapSectionProvider map[string]string
 
 func NewMapSectionProvider() SectionProvider {
-    return MapSectionProvider(map[string]string{})
+	return MapSectionProvider(map[string]string{})
 }
 
 func (sp MapSectionProvider) RawGet(key string) string {
-    ret, ok := sp[key]
-    if !ok {
-        return ""
-    }
-    return ret
+	ret, ok := sp[key]
+	if !ok {
+		return ""
+	}
+	return ret
 }
 
 func (sp MapSectionProvider) RawSet(key string, value string) bool {
-    sp[key] = value
-    return true
+	sp[key] = value
+	return true
 }
 
 func (sp MapSectionProvider) RawHasKey(key string) bool {
-    _, ok := sp[key]
-    return ok
+	_, ok := sp[key]
+	return ok
 }
 
 type envSectionProvider int
@@ -40,22 +40,22 @@ type envSectionProvider int
 var EnvSectionProvider SectionProvider = envSectionProvider(0)
 
 func (envSectionProvider) RawGet(key string) string {
-    return os.Getenv(key)
+	return os.Getenv(key)
 }
 
 func (envSectionProvider) RawSet(key string, value string) bool {
-    err := os.Setenv(key, value)
-    if err != nil {
-        reportError(err, map[string]interface{}{
-            "action": "Setenv",
-            "key":    key,
-        })
-        return false
-    }
-    return true
+	err := os.Setenv(key, value)
+	if err != nil {
+		reportError(err, map[string]interface{}{
+			"action": "Setenv",
+			"key":    key,
+		})
+		return false
+	}
+	return true
 }
 
 func (envSectionProvider) RawHasKey(key string) bool {
-    _, ok := os.LookupEnv(key)
-    return ok
+	_, ok := os.LookupEnv(key)
+	return ok
 }


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** Ignored/swallowed errors
**Impact:** `os.Setenv` failures were being silently swallowed and inverted. The operation returning an error would evaluate `!= nil` to `true`, mistakenly reporting success and masking the failure. This masks underlying environment configuration bugs and violates the centralized error handling requirement.
**Fix:**
- Implemented `reportError(err error, context map[string]interface{})` in `error.go` to establish the required centralized error handler.
- Updated `envSectionProvider.RawSet` in `sectionprovider.go` to explicitly check the error from `os.Setenv`, pass it to `reportError` with context (the key) if it fails, and return the correct boolean flag (`false` for failure, `true` for success).
- Appended a single-line journal entry to `.jules/sentinel.md` recording the vulnerability pattern for future reference.
**Verification:**
- Ran `go test -v ./...` which successfully passed all unit tests.
- Verified pre-commit constraints (no downloaded binaries/artifacts like `install-mise.sh` staged).

### Assumptions
- A simple `log.Printf` is an acceptable starting implementation for the required centralized `reportError` function given Sentry is not yet set up, as long as it correctly structures the error and context.
- Returning `false` on a `Setenv` failure correctly matches the semantic expectation of the `RawSet` boolean success return type.

### Alternatives Not Chosen
- Skipping the creation of `reportError` and directly using `log.Printf` at the call site. This was rejected because the global instructions strictly mandate the creation and use of a single, centralized error-reporting function.

### How To Pivot
- If a more sophisticated error reporting backend (like Sentry) is desired immediately, the `reportError` function in `error.go` can be updated without changing the call sites.

### Next Knobs
- `error.go`: Update the `reportError` implementation to integrate with a specific telemetry/error tracking backend (e.g., Sentry, Datadog).
- `sectionprovider.go`: Add more detailed contextual metadata to the `reportError` map if needed.

---
*PR created automatically by Jules for task [6717087515152282153](https://jules.google.com/task/6717087515152282153) started by @lucasew*